### PR TITLE
Exclude FAIG-installer/** from mkdocs build

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -125,6 +125,7 @@ plugins:
   - exclude:
       glob:
         - "README.md"
+        - "FAIG-installer/**"
   - awesome-pages
   - search
   - content-tabs


### PR DESCRIPTION
## Summary
- Adds `FAIG-installer/**` to the `exclude` plugin glob in `mkdocs.yml`.
- Stops mkdocs from rendering the 37 `.md` files inside `ai-2026/FAIG-installer/` as HTML, and removes the folder from the navigation prev/next chain.

## Why
`FAIG-installer/` is internal infrastructure tooling (terraform modules, Helm charts, dockerfiles, Python apps, plus README/SPEC/PLAN/DESIGN markdown). It was unintentionally being published to `canada.amerintlxperts.com/ai/FAIG-installer/...` and was inserting itself between AI-Driven-Security-Policy-Optimization and FortiWeb-AI-Security in the navigation order, breaking the "Previous" button on the first FortiWeb page.

The folder cannot be renamed (path is hardcoded in `provision-faig-session.yml`, `destroy-faig-session.yml`, and `.gitattributes` LFS filters in ai-2026), so adding a single glob to the central mkdocs config is the smallest safe change.

This change is global to every content site that uses `theme/mkdocs.yml` — but `FAIG-installer/` exists only in ai-2026, so it's a no-op for all other repos (secops-2026, enterprise-protection-2026, landing pages).

## Test plan
- [ ] Merge and trigger a rebuild of `ai-2026` (Build and Deploy (Canada) workflow).
- [ ] Confirm mkdocs build log no longer reports any `Doc file 'FAIG-installer/...'` warnings.
- [ ] Spot-check that `https://canada.amerintlxperts.com/ai/FAIG-installer/README.html` (or any other previously-rendered FAIG-installer page) returns 404.
- [ ] Open the first page of FortiWeb-AI-Security on the published site and confirm the "Previous" footer link goes to the last lab page of AI-Driven-Security-Policy-Optimization.
- [ ] Repeat the spot-check for the latam build (`latam.amerintlxperts.com/ai/...`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)